### PR TITLE
add init for activemq input plugin

### DIFF
--- a/plugins/inputs/activemq/activemq.go
+++ b/plugins/inputs/activemq/activemq.go
@@ -251,7 +251,6 @@ func (a *ActiveMQ) Gather(acc telegraf.Accumulator) error {
 	if a.client == nil {
 		a.Init()
 	}
-	
 	dataQueues, err := a.GetMetrics(a.QueuesURL())
 	if err != nil {
 		return err

--- a/plugins/inputs/activemq/activemq.go
+++ b/plugins/inputs/activemq/activemq.go
@@ -248,6 +248,10 @@ func (a *ActiveMQ) GatherSubscribersMetrics(acc telegraf.Accumulator, subscriber
 }
 
 func (a *ActiveMQ) Gather(acc telegraf.Accumulator) error {
+	if a.client == nil {
+		a.Init()
+	}
+	
 	dataQueues, err := a.GetMetrics(a.QueuesURL())
 	if err != nil {
 		return err


### PR DESCRIPTION
nil pointer dereference when exec "telegraf  --input-filter activemq --test"

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
